### PR TITLE
Fix for Chandra.Maneuver test failure

### DIFF
--- a/Quaternion/Quaternion.py
+++ b/Quaternion/Quaternion.py
@@ -605,7 +605,8 @@ class Quat(object):
         mult[...,1] =  q1[...,2] * q2[...,0] + q1[...,3] * q2[...,1] - q1[...,0] * q2[...,2] + q1[...,1] * q2[...,3]
         mult[...,2] = -q1[...,1] * q2[...,0] + q1[...,0] * q2[...,1] + q1[...,3] * q2[...,2] + q1[...,2] * q2[...,3]
         mult[...,3] = -q1[...,0] * q2[...,0] - q1[...,1] * q2[...,1] - q1[...,2] * q2[...,2] + q1[...,3] * q2[...,3]
-        return Quat(q=mult)
+        shape = self.q.shape if len(self.q.shape) > len(quat2.q.shape) else quat2.q.shape
+        return Quat(q=mult.reshape(shape))
 
     def inv(self):
         """

--- a/Quaternion/Quaternion.py
+++ b/Quaternion/Quaternion.py
@@ -270,14 +270,20 @@ class Quat(object):
 
     def _get_ra(self):
         """Retrieve RA term from equatorial system in degrees"""
+        if not self.shape:
+            return float(self.equatorial[..., 0].reshape(self.shape))
         return self.equatorial[..., 0].reshape(self.shape)
 
     def _get_dec(self):
         """Retrieve Dec term from equatorial system in degrees"""
+        if not self.shape:
+            return float(self.equatorial[..., 1].reshape(self.shape))
         return self.equatorial[..., 1].reshape(self.shape)
 
     def _get_roll(self):
         """Retrieve Roll term from equatorial system in degrees"""
+        if not self.shape:
+            return float(self.equatorial[..., 2].reshape(self.shape))
         return self.equatorial[..., 2].reshape(self.shape)
 
     ra = property(_get_ra)

--- a/Quaternion/tests/test_all.py
+++ b/Quaternion/tests/test_all.py
@@ -134,9 +134,9 @@ def test_from_eq_vectorized():
 
 def test_from_eq_shapes():
     q = Quat(equatorial=equatorial_23[0, 0])
-    assert q.ra.shape == ()
-    assert q.dec.shape == ()
-    assert q.roll.shape == ()
+    assert np.array(q.ra).shape == ()
+    assert np.array(q.dec).shape == ()
+    assert np.array(q.roll).shape == ()
     assert q.q.shape == (4, )
     assert q.equatorial.shape == (3, )
     assert q.transform.shape == (3, 3)
@@ -426,3 +426,8 @@ def test_copy():
     q1 = Quat(equatorial=eq)
     eq[-1] = 0
     assert not np.all(q1.equatorial == eq)
+
+def test_format():
+    # this is to test standard usage downstream
+    q = Quat(q_23[0, 0])
+    print(f'ra={q.ra:.5f}, dec={q.dec:.5f}, roll={q.roll:.5f}')

--- a/Quaternion/tests/test_all.py
+++ b/Quaternion/tests/test_all.py
@@ -384,9 +384,15 @@ def test_div_mult():
     q1 = Quat((1, 2, 3))
     q2 = Quat((10, 20, 30))
     q12d = q1 / q2
+    assert q1.shape == q12d.shape
+    assert q1.shape == q1.inv().shape
     q12m = q1 * q2.inv()
+    assert q1.shape == q12m.shape
     assert np.all(q12d.q == q12m.q)
 
+    q3 = Quat(equatorial=[[10, 20, 30]])
+    assert (q1*q3).shape != q1.shape
+    assert (q1*q3).shape == q3.shape
 
 def test_mult_vectorized():
     q1 = Quat(q=q_23[:1, :2])  # (shape (2,1)


### PR DESCRIPTION
Copying my comment from Issue #18 here:

The problem is in the multiplication. All attributes ere being squeezed to the right shape, but when multiplying two quaternions the result is being inadvertently reshaped, because the result is created from the two input quaternions **_after_** applying np.atleast_2d.

One solution is to check the shape of the original quaternions and reshape after the multiplication operation.

While doing this, I realized that there is an implicit broadcasting. We did not think of a generic broadcasting, but the current behavior allows one to do this:
```python
q2 = Quaternion.Quat(equatorial=[[10, 20, 30]])  # shape (1,)
q1 = Quaternion.Quat(equatorial=[1, 2, 3])  # shape ()
q3 = q1 * q2
```
This is because there is a check that both quaternions have the same shape, but again this is done after np.atleast_2d.

Options:

1. Forbid the operation above (by requiring the same shape: q1.shape == q2.shape)
2. Allow this limited broadcasting by setting the output's shape to the largest of the input shapes

Closes #18

