### PR TITLE
Add rotate_x_to_vec class method (from Ska.quatutil)

### DIFF
--- a/Quaternion/Quaternion.py
+++ b/Quaternion/Quaternion.py
@@ -703,6 +703,64 @@ class Quat(object):
 
         self.__dict__.update(state)
 
+    @classmethod
+    def rotate_x_to_vec(cls, vec, method='radec'):
+        """Generate quaternion that rotates X-axis into ``vec``.
+
+        The ``method`` parameter can take one of three values: "shortest",
+        "keep_z", or "radec" (default).  The "shortest" method takes the shortest
+        path between the two vectors.  The "radec" method does the transformation
+        as the corresponding (RA, Dec, Roll=0) attitude.  The "keep_z" method does
+        a roll about X-axis (followed by the "shortest" path) such that the
+        transformed Z-axis is in the original X-Z plane.  In equations::
+
+        T: "shortest" quaternion taking X-axis to vec
+        Rx(theta): Rotation by theta about X-axis = [[1,0,0], [0,c,s], [0,-s,c]]
+        Z: Z-axis [0,0,1]
+
+        [T * Rx(theta) * Z]_y = 0
+        T[1,1] * sin(theta) + T[1,2]*cos(theta) = 0
+        theta = atan2(T[1,2], T[1,1])
+
+        :param vec: Input 3-vector
+        :param method: method for determining path (shortest|keep_z|radec)
+        :returns: Quaternion object
+        """
+        x = np.array([1., 0, 0])
+        vec = normalize(vec)
+        if vec.shape != (3,):
+            raise ValueError('vec must be a single 3-vector')
+
+        if method in ("shortest", "keep_z"):
+            dot = np.dot(x, vec)
+            if abs(dot) > 1 - 1e-8:
+                x = normalize(np.array([1., 0., 1e-7]))
+                dot = np.dot(vec, x)
+            angle = np.arccos(dot)
+            axis = normalize(np.cross(x, vec))
+            sin_a = np.sin(angle / 2)
+            cos_a = np.cos(angle / 2)
+            q = cls([axis[0] * sin_a,
+                     axis[1] * sin_a,
+                     axis[2] * sin_a,
+                     cos_a])
+
+            if method == "keep_z":
+                T = q.transform
+                theta = np.arctan2(T[1, 2], T[1, 1])
+                qroll = cls([0, 0, np.rad2deg(theta)])
+                q = q * qroll
+
+        elif method == "radec":
+            ra = np.degrees(np.arctan2(vec[1], vec[0]))
+            dec = np.degrees(np.arcsin(vec[2]))
+            q = cls([ra, dec, 0])
+
+        else:
+            raise ValueError('method must be one of "shortest", "keep_z" or "radec"')
+
+        return q
+
 
 def normalize(array):
     """


### PR DESCRIPTION
## Description

This copies the only Quaternion-specific functionality from Ska.quatutil into the Quat class as a class method.

Related to https://github.com/sot/chandra_aca/pull/104 and https://github.com/sot/chandra_aca/issues/102.

## Testing

- [x] Passes unit tests on MacOS
- [x] Functional testing (added new regression test and copied existing functional tests)
