### PR TITLE
Make Quat behave more like ndarray (item access, iteration, reshaping etc)

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,0 +1,19 @@
+name: Python flake8 check
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - name: Lint with flake8
+      run: |
+        pip install flake8
+        flake8 . --count --exclude=docs --ignore=E402,W503,F541 --max-line-length=100 --show-source --statistics

--- a/Quaternion/Quaternion.py
+++ b/Quaternion/Quaternion.py
@@ -2,7 +2,8 @@
 """
 Quaternion provides a class for manipulating quaternion objects.  This class provides:
 
-  - convenient ways to deal with rotation representations (equatorial coordinates, matrix and quaternion):
+  - convenient ways to deal with rotation representations (equatorial
+    coordinates, matrix and quaternion):
 
     - a constructor to initialize from rotations in various representations,
     - conversion methods to the different representations.
@@ -83,7 +84,8 @@ class Quat(object):
       >>> (q2 * q1).equatorial
       array([ 353.37684725,   34.98868888,   47.499696  ])
 
-    Note that each step is as described in the section :ref:`Equatorial -> Matrix <equatorialmatrix>`
+    Note that each step is as described in the section
+    :ref:`Equatorial -> Matrix <equatorialmatrix>`
 
       >>> q1 = Quat(equatorial=(20, 0, 0))
       >>> q2 = Quat(equatorial=(0, 30, 0))
@@ -114,7 +116,8 @@ class Quat(object):
 
       >>> dq = q1.dq(q2)
 
-    When dealing with a collection of quaternions, it is much faster to operate on all of them at a time::
+    When dealing with a collection of quaternions, it is much faster to operate
+    on all of them at a time::
 
       >>> eq1 = [[ 30.000008,  39.999999,  49.999995],
       ...        [ 30.000016,  39.999999,  49.99999 ],
@@ -195,7 +198,7 @@ class Quat(object):
                 try:
                     shape = attitude.shape
                     shape = f' (shape {shape})'
-                except Exception as e:
+                except Exception:
                     shape = ''
                 raise TypeError(
                     f"attitude argument{shape} is not one of an allowed type:"
@@ -272,7 +275,7 @@ class Quat(object):
                 self._q = self._equatorial2quat()
             elif self._T is not None:
                 self._q = self._transform2quat()
-        return self._q.reshape(self.shape+(4,))
+        return self._q.reshape(self.shape + (4,))
 
     # use property to make this get/set automatic
     q = property(_get_q, _set_q)
@@ -307,7 +310,7 @@ class Quat(object):
             elif self._T is not None:
                 self._q = self._transform2quat()
                 self._equatorial = self._quat2equatorial()
-        return self._equatorial.reshape(self.shape+(3,))
+        return self._equatorial.reshape(self.shape + (3,))
 
     equatorial = property(_get_equatorial, _set_equatorial)
 
@@ -396,7 +399,7 @@ class Quat(object):
                 self._T = self._quat2transform()
             elif self._equatorial is not None:
                 self._T = self._equatorial2transform()
-        return self._T.reshape(self.shape+(3, 3))
+        return self._T.reshape(self.shape + (3, 3))
 
     transform = property(_get_transform, _set_transform)
 
@@ -438,7 +441,6 @@ class Quat(object):
         # from shape (3, N) to (N, 3), where N can be an arbitrary tuple
         # e.g. (3, 2, 5) -> (2, 5, 3) (np.transpose would give (2, 3, 5))
         return np.moveaxis(np.array([ra, dec, roll]), 0, -1)
-
 
 #  _quat2transform is largely from Enthought's quaternion.rotmat, though this math is
 #  probably from Hamilton.
@@ -535,9 +537,9 @@ class Quat(object):
 
         # This is the transpose of the transformation matrix (related to translation
         # of original perl code
-        rmat = np.array([[ca * cd,                    sa * cd,                  sd],
-                         [-ca * sd * sr - sa * cr,   -sa * sd * sr + ca * cr,   cd * sr],
-                         [-ca * sd * cr + sa * sr,   -sa * sd * cr - ca * sr,   cd * cr]])
+        rmat = np.array([[ca * cd,                    sa * cd,                  sd],  # noqa
+                         [-ca * sd * sr - sa * cr,   -sa * sd * sr + ca * cr,   cd * sr],  # noqa
+                         [-ca * sd * cr + sa * sr,   -sa * sd * cr - ca * sr,   cd * cr]])  # noqa
 
         return np.moveaxis(np.moveaxis(rmat, 0, -1), 0, -2)
 
@@ -647,10 +649,10 @@ class Quat(object):
         q2 = np.atleast_2d(quat2.q)
         assert q1.shape == q2.shape
         mult = np.zeros(q1.shape)
-        mult[...,0] =  q1[...,3] * q2[...,0] - q1[...,2] * q2[...,1] + q1[...,1] * q2[...,2] + q1[...,0] * q2[...,3]
-        mult[...,1] =  q1[...,2] * q2[...,0] + q1[...,3] * q2[...,1] - q1[...,0] * q2[...,2] + q1[...,1] * q2[...,3]
-        mult[...,2] = -q1[...,1] * q2[...,0] + q1[...,0] * q2[...,1] + q1[...,3] * q2[...,2] + q1[...,2] * q2[...,3]
-        mult[...,3] = -q1[...,0] * q2[...,0] - q1[...,1] * q2[...,1] - q1[...,2] * q2[...,2] + q1[...,3] * q2[...,3]
+        mult[...,0] =  q1[...,3] * q2[...,0] - q1[...,2] * q2[...,1] + q1[...,1] * q2[...,2] + q1[...,0] * q2[...,3]  # noqa
+        mult[...,1] =  q1[...,2] * q2[...,0] + q1[...,3] * q2[...,1] - q1[...,0] * q2[...,2] + q1[...,1] * q2[...,3]  # noqa
+        mult[...,2] = -q1[...,1] * q2[...,0] + q1[...,0] * q2[...,1] + q1[...,3] * q2[...,2] + q1[...,2] * q2[...,3]  # noqa
+        mult[...,3] = -q1[...,0] * q2[...,0] - q1[...,1] * q2[...,1] - q1[...,2] * q2[...,2] + q1[...,3] * q2[...,3]  # noqa
         shape = self.q.shape if len(self.q.shape) > len(quat2.q.shape) else quat2.q.shape
         return Quat(q=mult.reshape(shape))
 
@@ -808,4 +810,4 @@ def normalize(array):
 
     """
     quat = np.array(array)
-    return np.squeeze(quat/np.sqrt(np.sum(quat * quat, axis=-1, keepdims=True)))
+    return np.squeeze(quat / np.sqrt(np.sum(quat * quat, axis=-1, keepdims=True)))

--- a/Quaternion/Quaternion.py
+++ b/Quaternion/Quaternion.py
@@ -46,6 +46,11 @@ from astropy.utils import ShapedLikeNDArray
 
 
 class Quat(ShapedLikeNDArray):
+    # None of the base class method functions are defined for quaternions.
+    # These include things like min, max, round, all, etc. Calling these numpy
+    # functions on Quat just goes to the numpy function, which may or may not
+    # do something or else give an exception.
+    _METHOD_FUNCTIONS = {}
 
     """
     Quaternion class
@@ -460,16 +465,18 @@ class Quat(ShapedLikeNDArray):
             q = apply_method(qsa)['quat']
 
         # Get a new instance of our class and set its attributes directly.
-        out = super().__new__(cls or self.__class__)
+        cls = cls or self.__class__
+        out = cls.__new__(cls)
         out._q = np.atleast_2d(q)
         out._shape = q.shape[:-1]
+
         return out
 
     def __getitem__(self, item):
         if isinstance(item, tuple) and len(item) > self.ndim:
             raise IndexError('too many indices for array')
 
-        out = super().__new__(self.__class__)
+        out = self.__class__.__new__(self.__class__)
         q = self.q[item]
         out._q = np.atleast_2d(q)
         out._shape = q.shape[:-1]

--- a/Quaternion/Quaternion.py
+++ b/Quaternion/Quaternion.py
@@ -181,8 +181,8 @@ class Quat(ShapedLikeNDArray):
         return self
 
     def __init__(self, attitude=None, transform=None, q=None, equatorial=None):
-        npar = (int(attitude is not None) + int(transform is not None) +
-                int(q is not None) + int(equatorial is not None))
+        npar = (int(attitude is not None) + int(transform is not None)
+                + int(q is not None) + int(equatorial is not None))
         if npar != 1:
             raise ValueError(
                 f'{npar} arguments passed to constructor that takes only one of'
@@ -445,7 +445,7 @@ class Quat(ShapedLikeNDArray):
             broadcast : ``_apply(np.broadcast, shape=new_shape)``
         """
         if callable(method):
-            apply_method = lambda array: method(array, *args, **kwargs)
+            apply_method = lambda array: method(array, *args, **kwargs)  # noqa
         else:
             apply_method = operator.methodcaller(method, *args, **kwargs)
 

--- a/Quaternion/Quaternion.py
+++ b/Quaternion/Quaternion.py
@@ -720,7 +720,8 @@ class Quat(ShapedLikeNDArray):
         """
         q1 = np.atleast_2d(self.q)
         q2 = np.atleast_2d(quat2.q)
-        assert q1.shape == q2.shape
+        if q1.shape != q2.shape:
+            q1, q2 = np.broadcast_arrays(q1, q2)
         mult = np.zeros(q1.shape)
         mult[...,0] =  q1[...,3] * q2[...,0] - q1[...,2] * q2[...,1] + q1[...,1] * q2[...,2] + q1[...,0] * q2[...,3]  # noqa
         mult[...,1] =  q1[...,2] * q2[...,0] + q1[...,3] * q2[...,1] - q1[...,0] * q2[...,2] + q1[...,1] * q2[...,3]  # noqa

--- a/Quaternion/Quaternion.py
+++ b/Quaternion/Quaternion.py
@@ -293,6 +293,8 @@ class Quat(object):
 
         """
         self._equatorial = np.atleast_2d(np.array(equatorial))
+        self._q = None
+        self._transform = None
 
     def _get_equatorial(self):
         """Retrieve [RA, Dec, Roll]
@@ -378,6 +380,8 @@ class Quat(object):
         if transform.ndim == 2:
             transform = transform[np.newaxis]
         self._T = transform
+        self._q = None
+        self._equatorial = None
 
     def _get_transform(self):
         """

--- a/Quaternion/Quaternion.py
+++ b/Quaternion/Quaternion.py
@@ -281,7 +281,7 @@ class Quat(ShapedLikeNDArray):
         :param q: list or array of normalized quaternion elements
         """
         q = np.array(q)
-        shape = q.shape[:-1]
+        shape = q.shape[:-1]  # Capture input shape sans 4-vector dimension
         q = np.atleast_2d(q)
         if np.any((np.sum(q ** 2, axis=-1, keepdims=True) - 1.0) > 1e-6):
             raise ValueError(
@@ -326,10 +326,11 @@ class Quat(ShapedLikeNDArray):
 
         """
         equatorial = np.array(equatorial)
+        shape = equatorial.shape[:-1]  # Capture input shape sans 3-vector dimension
         self._equatorial = np.atleast_2d(equatorial)
         self._q = None
         self._transform = None
-        self._shape = equatorial.shape[:-1]
+        self._shape = shape
 
     @property
     def ra(self):
@@ -413,10 +414,11 @@ class Quat(ShapedLikeNDArray):
         :param t: 3x3 array/numpy array
         """
         transform = np.array(t)
+        shape = transform.shape[:-2]  # Capture input shape sans matrix dimensions
         self._T = np.atleast_3d(transform)
         self._q = None
         self._equatorial = None
-        self._shape = transform.shape[:-2]
+        self._shape = shape
 
     def _apply(self, method, *args, **kwargs):
         """Create a new Quat object, possibly applying a method to self.q.

--- a/Quaternion/__init__.py
+++ b/Quaternion/__init__.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import ska_helpers
 
-from .Quaternion import *
+from .Quaternion import *  # noqa
 
 __version__ = ska_helpers.get_version(__package__)
 

--- a/Quaternion/tests/test_all.py
+++ b/Quaternion/tests/test_all.py
@@ -467,6 +467,37 @@ def test_scalar_attribute_types():
         assert type(getattr(q, attr)) is typ
 
 
+def test_mult_and_dq_broadcasted():
+    """Test mult and delta quat of Quats with different but broadcastable shapes.
+    """
+    q2 = Quat(equatorial=np.arange(18).reshape(3, 2, 3))
+    q1 = Quat(equatorial=[[10, 20, 30], [40, 50, 60]])
+    q0 = Quat(equatorial=[10, 20, 30])
+    # (3,2) * () = (3,2)
+    q20 = q2 * q0
+    dq20 = q2.dq(q0)
+    assert q20.shape == (3, 2)
+    assert dq20.shape == (3, 2)
+    for ii in range(3):
+        for jj in range(2):
+            qq = q2[ii, jj] * q0
+            dq = q2[ii, jj].dq(q0)
+            assert np.allclose(qq.q, q20.q[ii, jj])
+            assert np.allclose(dq.q, dq20.q[ii, jj])
+
+    # (3,2) * (2,) = (3,2)
+    q21 = q2 * q1
+    dq21 = q2.dq(q1)
+    assert q21.shape == (3, 2)
+    assert dq21.shape == (3, 2)
+    for ii in range(3):
+        for jj in range(2):
+            qq = q2[ii, jj] * q1[jj]
+            dq = q2[ii, jj].dq(q1[jj])
+            assert np.allclose(qq.q, q21.q[ii, jj])
+            assert np.allclose(dq.q, dq21.q[ii, jj])
+
+
 def test_array_attribute_types():
     q = Quat(equatorial=[[10, 20, 30]])  # 1-d
     attrs = ['ra', 'dec', 'roll', 'ra0', 'roll0', 'pitch', 'yaw', 'transform', 'q']

--- a/Quaternion/tests/test_all.py
+++ b/Quaternion/tests/test_all.py
@@ -599,3 +599,14 @@ def test_rotate_about_vec_exceptions():
     with pytest.raises(ValueError, match='quaternion must be a scalar'):
         q2.rotate_about_vec([1, 2, 3], 25)
 
+
+@pytest.mark.parametrize('attr', ['q', 'equatorial', 'transform'])
+def test_setting_different_shape(attr):
+    q0 = Quat([1, 2, 3])
+    q1 = Quat(equatorial=[[3, 1, 2],
+                          [4, 5, 6]])
+    assert q1.shape == (2,)
+    val = getattr(q1, attr)
+    setattr(q0, attr, val)
+    assert q0.shape == q1.shape
+    assert np.all(getattr(q0, attr) == getattr(q1, attr))

--- a/Quaternion/tests/test_all.py
+++ b/Quaternion/tests/test_all.py
@@ -12,6 +12,7 @@ def indices(t):
     for k in itertools.product(*[range(i) for i in t]):
         yield k
 
+
 def normalize_angles(x, xmin, xmax):
     while np.any(x >= xmax):
         x -= np.where(x > xmax, 360, 0)
@@ -32,11 +33,11 @@ equatorial_23 = np.array([[[10, 20, 30],
                            [10, 50, 30],
                            [10, -50, -30]]], dtype=float)
 
-q_23 = np.zeros(equatorial_23[..., 0].shape+(4,))
+q_23 = np.zeros(equatorial_23[..., 0].shape + (4,))
 for _i, _j in indices(equatorial_23.shape[:-1]):
     q_23[_i, _j] = Quat(equatorial_23[_i, _j]).q
 
-transform_23 = np.zeros(equatorial_23[..., 0].shape+(3, 3))
+transform_23 = np.zeros(equatorial_23[..., 0].shape + (3, 3))
 for _i, _j in indices(transform_23.shape[:-2]):
     transform_23[_i, _j] = Quat(equatorial_23[_i, _j]).transform
 
@@ -77,11 +78,11 @@ def test_init_exceptions():
     with pytest.raises(ValueError):
         _ = Quat(q=[[[1., 0., 0., 1.]]])  # q not normalized
     with pytest.raises(ValueError):
-        _ = Quat([0,1,'s'])  # could not convert string to float
+        _ = Quat([0, 1, 's'])  # could not convert string to float
 
 
 def test_from_q():
-    q = [0.26853582, -0.14487813,  0.12767944,  0.94371436]
+    q = [0.26853582, -0.14487813, 0.12767944, 0.94371436]
     q1 = Quat(q)
     q2 = Quat(q=q)
     q3 = Quat(q1)
@@ -95,8 +96,8 @@ def test_from_eq():
     q = Quat([ra, dec, roll])
     assert np.allclose(q.q[0], 0.26853582)
     assert np.allclose(q.q[1], -0.14487813)
-    assert np.allclose(q.q[2],  0.12767944)
-    assert np.allclose(q.q[3],  0.94371436)
+    assert np.allclose(q.q[2], 0.12767944)
+    assert np.allclose(q.q[3], 0.94371436)
     assert np.allclose(q.roll0, 30)
     assert np.allclose(q.ra0, 10)
     assert q.pitch == -q.dec
@@ -134,8 +135,9 @@ def test_from_eq_vectorized():
     assert np.all(q.equatorial == equatorial_23)
     assert np.all(q.transform == transform_23)
 
+
 def test_from_eq_shapes():
-    q = Quat(equatorial=[ 10., 20., 30.])
+    q = Quat(equatorial=[10., 20., 30.])
     assert np.array(q.ra0).shape == ()
     assert np.array(q.roll0).shape == ()
     assert np.array(q.ra).shape == ()
@@ -175,7 +177,7 @@ def test_from_transform():
     assert np.allclose(q.q[0], -0.26853582)
     assert np.allclose(q.q[1], 0.14487813)
     assert np.allclose(q.q[2], -0.12767944)
-    assert np.allclose(q.q[3],  0.94371436)
+    assert np.allclose(q.q[3], 0.94371436)
 
     q = Quat(q0.transform)
     assert np.allclose(q.roll0, 30)
@@ -205,11 +207,12 @@ def test_from_transform_vectorized():
     assert np.allclose(q.q, q_23)
     # to compare roll, it has to be normalized to within a fixed angular range (0, 360).
     eq = np.array(q.equatorial)
-    normalize_angles(eq[...,-1], 0, 360)
+    normalize_angles(eq[..., -1], 0, 360)
     eq_23 = np.array(equatorial_23)
     normalize_angles(eq_23[..., -1], 0, 360)
     assert np.allclose(eq, eq_23)
     assert np.allclose(q.transform, transform_23)
+
 
 def test_eq_from_transform():
     # this raises 'Unexpected negative norm' exception due to roundoff in copy/paste above
@@ -230,11 +233,11 @@ def test_from_q_vectorized():
     q = Quat(q=q_23)
     assert q.shape == (2, 3)
     # this also tests that quaternions with negative scalar component are flipped
-    flip = np.sign(q_23[...,-1]).reshape((2,3,1))
-    assert np.allclose(q.q, q_23*flip)
+    flip = np.sign(q_23[..., -1]).reshape((2, 3, 1))
+    assert np.allclose(q.q, q_23 * flip)
     # to compare roll, it has to be normalized to within a fixed angular range (0, 360).
     eq = np.array(q.equatorial)
-    normalize_angles(eq[...,-1], 0, 360)
+    normalize_angles(eq[..., -1], 0, 360)
     eq_23 = np.array(equatorial_23)
     normalize_angles(eq_23[..., -1], 0, 360)
     assert np.allclose(eq, eq_23, rtol=0)
@@ -274,6 +277,7 @@ def test_inv_vectorized():
     for i in indices(q1.shape):
         # check that Quat(q).inv().q[i] == Quat(q[i]).inv().q
         assert np.all(q1_inv.q[i] == Quat(q=q1.q[i]).inv().q)
+
 
 def test_dq():
     q1 = Quat((20, 30, 0))
@@ -401,14 +405,15 @@ def test_div_mult():
     assert np.all(q12d.q == q12m.q)
 
     q3 = Quat(equatorial=[[10, 20, 30]])
-    assert (q1*q3).shape != q1.shape
-    assert (q1*q3).shape == q3.shape
+    assert (q1 * q3).shape != q1.shape
+    assert (q1 * q3).shape == q3.shape
+
 
 def test_mult_vectorized():
     q1 = Quat(q=q_23[:1, :2])  # (shape (2,1)
     q2 = Quat(q=q_23[1:, 1:])  # (shape (2,1)
     assert q1.q.shape == q2.q.shape
-    q12 = q1*q2
+    q12 = q1 * q2
     assert q12.q.shape == q1.q.shape
 
 
@@ -420,7 +425,7 @@ def test_normalize():
 
 def test_copy():
     # data members must be copies so they are not modified by accident
-    q = np.array(q_23[0,0])
+    q = np.array(q_23[0, 0])
     q1 = Quat(q=q)
     q[-1] = 0
     assert q1.q[-1] != 0
@@ -501,8 +506,8 @@ def test_pickle():
         quaternions = pickle.load(f)
     for q in quaternions:
         assert np.all(np.isclose(q.q, [0.26853582, -0.14487813, 0.12767944, 0.94371436]))
-        assert np.all(np.isclose(q.equatorial, [ 10.,  20.,  30.]))
-        assert np.all(np.isclose(q.transform, [[ 0.92541658, -0.31879578, -0.20487413],
+        assert np.all(np.isclose(q.equatorial, [10., 20., 30.]))
+        assert np.all(np.isclose(q.transform, [[0.92541658, -0.31879578, -0.20487413],
                                                [0.16317591, 0.82317294, -0.54383814],
                                                [0.34202014, 0.46984631, 0.81379768]]))
 

--- a/Quaternion/tests/test_shaped.py
+++ b/Quaternion/tests/test_shaped.py
@@ -1,0 +1,111 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import numpy as np
+import pytest
+
+from .. import Quat
+
+
+@pytest.mark.parametrize('attr', ['q', 'equatorial', 'transform'])
+def test_getitem(attr):
+    """Test getitem and iteration"""
+    eqs = np.arange(24).reshape(2, 4, 3)
+    qs = Quat(equatorial=eqs)
+    for i in range(eqs.shape[0]):
+        for j in range(eqs.shape[1]):
+            val1 = getattr(qs[i, j], attr)
+            val2 = getattr(qs, attr)[i, j]
+            assert np.allclose(val1, val2)
+            assert val1.shape == val2.shape
+
+    for i in range(eqs.shape[0]):
+        val1 = getattr(qs[i], attr)
+        val2 = getattr(qs, attr)[i]
+        assert np.allclose(val1, val2)
+        assert val1.shape == val2.shape
+
+    for i, q_i in enumerate(qs):
+        val1 = getattr(q_i, attr)
+        val2 = getattr(qs, attr)[i]
+        assert np.allclose(val1, val2)
+        assert val1.shape == val2.shape
+
+
+shape_methods = ('copy', 'reshape', 'transpose', 'flatten', 'ravel', 'swapaxes',
+                 'diagonal', 'squeeze', 'take')
+@pytest.mark.parametrize('method', shape_methods)  # noqa
+def test_shape_changing_methods(method):
+    eqs = np.arange(4 * 1 * 3).reshape(4, 1, 3)
+    q1 = Quat(equatorial=eqs)
+    if method == 'take':
+        args = (3, 0)
+    elif method == 'squeeze':
+        args = (-1,)
+    elif method == 'reshape':
+        args = (2, 2)
+    elif method == 'swapaxes':
+        args = (0, 1)
+    else:
+        args = ()
+
+    val1 = getattr(q1, method)(*args).equatorial
+    val20 = getattr(q1.equatorial[..., 0], method)(*args)
+    val21 = getattr(q1.equatorial[..., 1], method)(*args)
+    val22 = getattr(q1.equatorial[..., 2], method)(*args)
+    val2 = np.stack([val20, val21, val22], axis=-1)
+    assert val1.shape == val2.shape
+    assert np.allclose(val1, val2)
+
+    val1 = getattr(q1, method)(*args).q
+    val20 = getattr(q1.q[..., 0], method)(*args)
+    val21 = getattr(q1.q[..., 1], method)(*args)
+    val22 = getattr(q1.q[..., 2], method)(*args)
+    val23 = getattr(q1.q[..., 3], method)(*args)
+    val2 = np.stack([val20, val21, val22, val23], axis=-1)
+    assert val1.shape == val2.shape
+    assert np.allclose(val1, val2)
+
+
+def test_shape_changing_T_property():
+    eqs = np.arange(4 * 1 * 3).reshape(4, 1, 3)
+    q1 = Quat(equatorial=eqs)
+
+    val1 = q1.T.equatorial
+    val20 = q1.equatorial[..., 0].T
+    val21 = q1.equatorial[..., 1].T
+    val22 = q1.equatorial[..., 2].T
+    val2 = np.stack([val20, val21, val22], axis=-1)
+
+    assert val1.shape == val2.shape
+    assert np.allclose(val1, val2)
+
+
+applicable_methods = [
+    (np.moveaxis, (0, 1)),
+    (np.rollaxis, (1,)),
+    (np.atleast_1d, ()),
+    (np.atleast_2d, ()),
+    (np.atleast_3d, ()),
+    (np.expand_dims, (1,)),
+    (np.broadcast_to, ((3, 4, 1),)),
+    (np.flip, ()),
+    (np.fliplr, ()),
+    (np.flipud, ()),
+    (np.rot90, ()),
+    (np.roll, (1,)),
+    (np.delete, ([0, 2], 0))
+]
+
+
+@pytest.mark.parametrize('method, args', applicable_methods)
+def test_applicable_methods(method, args):
+    eqs = np.arange(4 * 1 * 3).reshape(4, 1, 3)
+    q1 = Quat(equatorial=eqs)
+
+    val1 = method(q1, *args).equatorial
+    val20 = method(q1.equatorial[..., 0], *args)
+    val21 = method(q1.equatorial[..., 1], *args)
+    val22 = method(q1.equatorial[..., 2], *args)
+    val2 = np.stack([val20, val21, val22], axis=-1)
+
+    assert val1.shape == val2.shape
+    assert np.allclose(val1, val2)


### PR DESCRIPTION
## Description

This uses the astropy `ShapedLikeNDArray` class to provide support for a number of ndarray methods and in particular `__getitem__` and iteration. (ebbde49)

In addition:
- Fixes a minor bug where setting `transform` and `equatorial` did not unset the other components, leading to an inconsistent object. (1ef0574)
- For my sanity and to make sure new code is clean this fixes all the flake8 warnings (4534042, c5a413f).
- Support quat multiplication and `.dq()` for Quats that have different shape but are broadcastable.
   This should have been a new PR but it was just easier to work in this branch because of `__getitem__`. (696cef5)

## Testing

- [x] Passes unit tests on MacOS (with new tests)
- [n/a] Functional testing

For a quick demo: https://gist.github.com/taldcroft/a70fe6c206a9d6203fda1d5aaea9855e

@mhvk - check it out, NICE!