### PR TITLE
Add from_attitude class method for more permissive init

### DIFF
--- a/Quaternion/Quaternion.py
+++ b/Quaternion/Quaternion.py
@@ -896,7 +896,7 @@ class Quat(ShapedLikeNDArray):
             Attitude(s) as a Quat
         """
         if isinstance(att, Quat):
-            return att
+            return att.copy()
 
         # Input that works with Quat already
         try:

--- a/Quaternion/tests/test_all.py
+++ b/Quaternion/tests/test_all.py
@@ -551,6 +551,15 @@ def test_init_quat_from_attitude():
     assert np.allclose(q.equatorial, [[0, 1, 2],
                                       [3, 4, 5]])
 
+    # From existing Quat
+    q2 = Quat.from_attitude(q)
+    assert np.all(q.q == q2.q)
+    assert q is not q2
+
+    # Normal Quat initializer: 3-element list implies equatorial
+    q = Quat.from_attitude([10, 20, 30])
+    assert np.allclose(q.equatorial, [10, 20, 30])
+
     # 2-d list of Quat
     q = Quat.from_attitude([[Quat([0, 1, 2]), Quat([3, 4, 5])]])
     assert np.allclose(q.equatorial, [[[0, 1, 2],


### PR DESCRIPTION
## Description

This allows more permissive initialization of a Quaternion for cases when the input is known to be an attitude (instead of e.g. a 3x3 transform).

## Testing

- [x] Passes unit tests on MacOS (with new tests)
- [n/a] Functional testing
