### PR TITLE
Update QuatDescriptor for typed-descriptor-lazy-default

### DIFF
--- a/Quaternion/Quaternion.py
+++ b/Quaternion/Quaternion.py
@@ -1093,10 +1093,12 @@ class QuatDescriptor(TypedDescriptor):
     ----------
     default : QuatLike, optional
         Default value for the attribute.  If not specified, the default for the
-        attribute is ``None``.
+        attribute is ``None``. If the intent is to default to a particular attitude,
+        this must be a tuple such as ``(0, 0, 0, 1)`` or ``(0, 0, 0)`` or a ``Quat``
+        object. A list is not allowed.
     required : bool, optional
-        If ``True``, the attribute is required to be set explicitly when the object
-        is created. If ``False`` the default value is used if the attribute is not set.
+        If ``True``, the attribute is required to be set explicitly when the object is
+        created. If ``False`` the default value is used if the attribute is not set.
 
     Examples
     --------
@@ -1105,7 +1107,7 @@ class QuatDescriptor(TypedDescriptor):
     >>> @dataclass
     ... class MyClass:
     ...     att1: Quat = QuatDescriptor(required=True)
-    ...     att2: Quat = QuatDescriptor(default=[10, 20, 30])
+    ...     att2: Quat = QuatDescriptor(default=(10, 20, 30))
     ...     att3: Quat | None = QuatDescriptor()
     ...
     >>> obj = MyClass(att1=[0, 0, 0, 1])

--- a/Quaternion/tests/test_all.py
+++ b/Quaternion/tests/test_all.py
@@ -744,7 +744,7 @@ def test_quat_descriptor_is_required():
     assert np.allclose(obj.quat.equatorial, [10, 20, 30], rtol=0, atol=1e-10)
 
     with pytest.raises(
-        ValueError, match="cannot set required attribute 'quat' to None"
+        ValueError, match="attribute 'quat' is required and cannot be set to None"
     ):
         MyClass()
 
@@ -752,7 +752,7 @@ def test_quat_descriptor_is_required():
 def test_quat_descriptor_has_default():
     @dataclass
     class MyClass:
-        quat: Quat = QuatDescriptor(default=[10, 20, 30])
+        quat: Quat = QuatDescriptor(default=(10, 20, 30))
 
     obj = MyClass()
     assert np.allclose(obj.quat.equatorial, [10, 20, 30], rtol=0, atol=1e-10)


### PR DESCRIPTION
## Description

This makes a few changes for compatibility with https://github.com/sot/ska_helpers/pull/54.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(masters) ➜  cxotime git:(cxotime-descr) git rev-parse HEAD                                                             
f0f3d24d17f318c54b483e644ead80142b7439e1
(masters) ➜  cxotime git:(cxotime-descr) pytest
===================================================== test session starts ======================================================
platform darwin -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/aldcroft/git, configfile: pytest.ini
plugins: timeout-2.1.0, anyio-3.6.2
collected 235 items                                                                                                            

cxotime/tests/test_cxotime.py .......................................................................................... [ 38%]
........................................................................................................................ [ 89%]
.........................                                                                                                [100%]

===================================================== 235 passed in 2.15s ======================================================
```
Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
