### PR TITLE
bugfix: fix check for normalized quaternion

### DIFF
--- a/Quaternion/Quaternion.py
+++ b/Quaternion/Quaternion.py
@@ -390,9 +390,7 @@ class Quat(ShapedLikeNDArray):
         q = np.array(q)
         shape = q.shape[:-1]  # Capture input shape sans 4-vector dimension
         q = np.atleast_2d(q)
-        if np.any(q != 0.0) and np.any(
-            np.abs((np.sum(q**2, axis=-1, keepdims=True) - 1.0)) > 1e-6
-        ):
+        if np.any(np.abs((np.sum(q**2, axis=-1, keepdims=True) - 1.0)) > 1e-6):
             raise ValueError(
                 "Quaternions must be normalized so sum(q**2) == 1; use Quaternion.normalize"
             )

--- a/Quaternion/Quaternion.py
+++ b/Quaternion/Quaternion.py
@@ -390,7 +390,9 @@ class Quat(ShapedLikeNDArray):
         q = np.array(q)
         shape = q.shape[:-1]  # Capture input shape sans 4-vector dimension
         q = np.atleast_2d(q)
-        if np.any((np.sum(q**2, axis=-1, keepdims=True) - 1.0) > 1e-6):
+        if np.any(q != 0.0) and np.any(
+            np.abs((np.sum(q**2, axis=-1, keepdims=True) - 1.0)) > 1e-6
+        ):
             raise ValueError(
                 "Quaternions must be normalized so sum(q**2) == 1; use Quaternion.normalize"
             )

--- a/Quaternion/tests/test_all.py
+++ b/Quaternion/tests/test_all.py
@@ -88,6 +88,8 @@ def test_init_exceptions():
     with pytest.raises(ValueError):
         _ = Quat(q=[[[1.0, 0.0, 0.0, 1.0]]])  # q not normalized
     with pytest.raises(ValueError):
+        _ = Quat(q=[[[0.1, 0.0, 0.0, 0.1]]])  # q not normalized
+    with pytest.raises(ValueError):
         _ = Quat([0, 1, "s"])  # could not convert string to float
 
 

--- a/Quaternion/tests/test_all.py
+++ b/Quaternion/tests/test_all.py
@@ -47,11 +47,7 @@ for _i, _j in indices(transform_23.shape[:-2]):
 
 
 def test_shape():
-    q = Quat(
-        q=np.zeros(
-            4,
-        )
-    )
+    q = Quat(q=np.array([0., 0., 0., 1.]))
     assert q.shape == ()
     with pytest.raises(AttributeError):
         q.shape = (4,)

--- a/Quaternion/tests/test_all.py
+++ b/Quaternion/tests/test_all.py
@@ -47,7 +47,7 @@ for _i, _j in indices(transform_23.shape[:-2]):
 
 
 def test_shape():
-    q = Quat(q=np.array([0., 0., 0., 1.]))
+    q = Quat(q=np.array([0.0, 0.0, 0.0, 1.0]))
     assert q.shape == ()
     with pytest.raises(AttributeError):
         q.shape = (4,)


### PR DESCRIPTION
## Description

I discovered that the Quaternion can be initialized with an invalid `q`. 

In some places the class assumes that quaternions are normalized, and it tries to enforce that in the `q` property. However, the check is not correct, and instead it checks that the norm is less than 1. For example, the following does not raise:
```
from Quaternion import Quat
q = Quat([0, 0, 0, 0.1])
```

This PR fixes this and adds the corresponding test to catch the issue. 

Also, there was one test that was using `q=[0, 0, 0, 0]`, which is useless in all our use cases and can't be normalized. Using `q=[0, 0, 0, 0]` will raise an exception from now on and the test was fixed.

## Interface impacts
A bug was fixed in the constructor that allowed non-normalized quaternions. In particular, it allowed `Quat(q=[0, 0, 0,  0])`, which might be used (incorrectly) in some places. From now on this will raise an exception.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [x] Mac on version `4.3.1.dev4+g2db69e2`
- [ ] Linux
- [ ] Windows

```
(ska3-flight) javierg Quaternion $ pytest Quaternion/
========================================= test session starts =========================================
platform darwin -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/javierg/SAO/git, configfile: pytest.ini
plugins: timeout-2.1.0, anyio-3.6.2
collected 72 items                                                                                    

Quaternion/tests/test_all.py ..............................................                     [ 63%]
Quaternion/tests/test_shaped.py ..........................                                      [100%]

========================================= 72 passed in 3.83s ==========================================
(ska3-flight) javierg Quaternion $ python -c "import Quaternion; print(Quaternion.__version__)"
4.3.1.dev4+g2db69e2

```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
